### PR TITLE
Fixed splited error messages

### DIFF
--- a/django_remote_forms/forms.py
+++ b/django_remote_forms/forms.py
@@ -163,8 +163,13 @@ class RemoteForm(object):
 
             initial_data[name] = form_dict['fields'][name]['initial']
 
+        form_data = self.form.data.copy()
+
+        # Filter data to include only form fields data
+        form_data = {k: v for k, v in self.form.data.items() if k in list(self.fields)}
+
         if self.form.data:
-            form_dict['data'] = self.form.data
+            form_dict['data'] = form_data
         else:
             form_dict['data'] = initial_data
 

--- a/django_remote_forms/utils.py
+++ b/django_remote_forms/utils.py
@@ -10,7 +10,7 @@ def resolve_promise(o):
         o = [resolve_promise(x) for x in o]
     elif isinstance(o, Promise):
         try:
-            o = force_unicode(o)
+            o = force_text(o)
         except:
             # Item could be a lazy tuple or list
             try:


### PR DESCRIPTION
Fixed splited error messages due to use of deprecated function foce_unicode