### PR TITLE
Add default widget class to use them when field widget class is unknown

### DIFF
--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -180,7 +180,7 @@ class RemoteChoiceField(RemoteField):
         field_dict['choices'] = []
         for key, value in self.field.choices:
             field_dict['choices'].append({
-                'value': key,
+                'value': str(key),
                 'display': value
             })
 

--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django_remote_forms import logger, widgets
 from django import forms
 
+DEFAULT_REMOTE_WIDGET_CLASS_NAME = 'DefaultRemoteInput'
+
 
 class RemoteField(object):
     """
@@ -40,12 +42,12 @@ class RemoteField(object):
         remote_widget_class_name = 'Remote%s' % self.field.widget.__class__.__name__
         try:
             remote_widget_class = getattr(widgets, remote_widget_class_name)
-            remote_widget = remote_widget_class(self.field.widget, field_name=self.field_name)
         except Exception as e:
             logger.warning('Error serializing %s: %s', remote_widget_class_name, str(e))
-            widget_dict = {}
-        else:
-            widget_dict = remote_widget.as_dict()
+            remote_widget_class = getattr(widgets, DEFAULT_REMOTE_WIDGET_CLASS_NAME)
+
+        remote_widget = remote_widget_class(self.field.widget, field_name=self.field_name)
+        widget_dict = remote_widget.as_dict()
 
         field_dict['widget'] = widget_dict
 

--- a/django_remote_forms/forms.py
+++ b/django_remote_forms/forms.py
@@ -196,9 +196,12 @@ class RemoteForm(object):
 
         for field_name in file_fields:
             obj = form_dict['data'].get(field_name, None)
-            if getattr(obj, 'url', None):
-                form_dict['data'][field_name] = obj.url
-            else:
+            try:
+                if getattr(obj, 'url', None):
+                    form_dict['data'][field_name] = obj.url
+                else:
+                    form_dict['data'][field_name] = None
+            except ValueError:
                 form_dict['data'][field_name] = None
 
         return resolve_promise(form_dict)

--- a/django_remote_forms/forms.py
+++ b/django_remote_forms/forms.py
@@ -187,7 +187,7 @@ class RemoteForm(object):
 
         for field_name in comma_separated_fields:
             obj = form_dict['data'].get(field_name, '')
-            if isinstance(obj, str):
+            if obj and isinstance(obj, str):
                 form_dict['data'][field_name] = obj.split(',')
             elif isinstance(obj, list):
                 form_dict['data'][field_name] = obj

--- a/django_remote_forms/utils.py
+++ b/django_remote_forms/utils.py
@@ -1,5 +1,5 @@
 from django.utils.functional import Promise
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 def resolve_promise(o):
@@ -10,7 +10,7 @@ def resolve_promise(o):
         o = [resolve_promise(x) for x in o]
     elif isinstance(o, Promise):
         try:
-            o = force_text(o)
+            o = force_str(o)
         except:
             # Item could be a lazy tuple or list
             try:

--- a/django_remote_forms/widgets.py
+++ b/django_remote_forms/widgets.py
@@ -169,7 +169,7 @@ class RemoteSelect(RemoteWidget):
         widget_dict['choices'] = []
         for key, value in self.widget.choices:
             widget_dict['choices'].append({
-                'value': key,
+                'value': str(key),
                 'display': value
             })
 
@@ -233,7 +233,7 @@ class RemoteRadioSelect(RemoteSelect):
         for key, value in self.widget.choices:
             widget_dict['choices'].append({
                 'name': self.field_name or '',
-                'value': key,
+                'value': str(key),
                 'display': value
             })
 

--- a/django_remote_forms/widgets.py
+++ b/django_remote_forms/widgets.py
@@ -30,6 +30,15 @@ class RemoteInput(RemoteWidget):
         return widget_dict
 
 
+class DefaultRemoteInput(RemoteWidget):
+    def as_dict(self):
+        widget_dict = super(DefaultRemoteInput, self).as_dict()
+
+        widget_dict['input_type'] = 'text'
+
+        return widget_dict
+
+
 class RemoteTextInput(RemoteInput):
     def as_dict(self):
         return super(RemoteTextInput, self).as_dict()


### PR DESCRIPTION
Add default widget class to use them when field widget class is unknown to avoid empty widgets on Remote Forms